### PR TITLE
Fix issue with seamless iframe support

### DIFF
--- a/jquery.appear.js
+++ b/jquery.appear.js
@@ -19,6 +19,7 @@
     support_seamless_iframes: false
   };
   var $window = $(window);
+  var handle_seamless_iframe = false;
   var $iframe;
   var iframe_offset;
 
@@ -45,7 +46,7 @@
     selectors.push(selector);
     $prior_appeared.push();
   }
-  
+
   // "appeared" custom filter
   $.expr[':']['appeared'] = function(element) {
     var $element = $(element);
@@ -60,40 +61,40 @@
     var offset = $element.offset();
     var left = offset.left;
     var top = offset.top;
-        
-    if ($iframe) {
+
+    if (handle_seamless_iframe) {
       // handle the iframe being all or partially out of the top window's viewport
       var top_window_top = $(window.top).scrollTop();
       var top_window_bottom = top_window_top + $(window.top).height();
       var top_window_left = $(window.top).scrollLeft();
-      var top_window_right = top_window_left + $(window.top).width();			
+      var top_window_right = top_window_left + $(window.top).width();
       var iframe_top = iframe_offset.top;
       var iframe_bottom = iframe_top + $iframe.height();
       var iframe_left = iframe_offset.left;
       var iframe_right = iframe_left + $iframe.width();
-      
+
       if (top_window_top > iframe_bottom || // iframe is above the top window's viewport
           iframe_top > top_window_bottom || // iframe is below the top window's viewport
           top_window_left > iframe_right || // iframe is left of the top window's viewport
           iframe_left > top_window_right) { // iframe is right of the top window's viewport
         return false;
       }
-      
-      if (top_window_top > iframe_top) { 
+
+      if (top_window_top > iframe_top) {
         // the top of the iframe is outside of the top window's viewport, adjust to account for what is not visible
         viewport_top += (top_window_top - iframe_top);
       }
-      
+
       if (iframe_bottom > top_window_bottom) {
         // the bottom of the iframe is outside of the top window's viewport, adjust to account for what is not visible
         viewport_bottom -= (iframe_bottom - top_window_bottom);
       }
-      
+
       if(top_window_left > iframe_left){
         // the left of the iframe is outside of the top window's viewport, adjust to account for what is not visible
         viewport_left += (top_window_left - iframe_left);
       }
-      
+
       if(iframe_right > top_window_right){
         // the right of the iframe is outside of the top window's viewport, adjust to account for what is not visible
         viewport_right -= (iframe_right - top_window_right);
@@ -124,9 +125,14 @@
 
           setTimeout(process, opts.interval);
         };
-                
+
         if (opts.support_seamless_iframes && window.frameElement) {
           $iframe = $(window.frameElement);
+          // check if the iframe is seamless: has the seamless attribute (HTML5) or scrolling="no" (pre-HTML5)
+          handle_seamless_iframe = $iframe.attr('scrolling') === "no" || $iframe.is('[seamless]');
+        }
+
+        if (handle_seamless_iframe) {
           iframe_offset = $iframe.offset();
           $(window.top).scroll(on_check).resize(on_check);
         } else {


### PR DESCRIPTION
Updated code for supporting seamless iframes to check if the iframe is
actually seamless before applying the logic. When the iframe is not
seamless, the logic should be the same as when the page is not in an
iframe at all.

These changes assume that seamless iframes will have scrolling="no" or
the HTML5 seamless attribute.

I also fixed some of the tabs and spaces in the file.
